### PR TITLE
Fixing an edge-case bug

### DIFF
--- a/00.0_ Intro & Config.py
+++ b/00.0_ Intro & Config.py
@@ -196,6 +196,10 @@ class ZinggJob:
     # get list of jobs in databricks workspace
     job_resp = requests.get(f'https://{self.url}/api/2.0/jobs/list', headers=self._headers)
     
+    # Handle edge case where no jobs are present in the workspace, otherwise attempting to iterate over job_resp will throw an error
+    if len(job_resp.json()) == 0:
+        return None
+      
     # find job by name
     for job in job_resp.json().get('jobs'):
         if job.get('settings').get('name')==self.name:


### PR DESCRIPTION
If there are no jobs in the workspace we will currently throw an error - "TypeError: 'NoneType' object is not iterable"  - here since job_resp is empty. We can avoid the error by returning None early if the response is empty